### PR TITLE
Make it possible to provide own ILogger to DeribitV2Client. Fixes #10

### DIFF
--- a/.github/workflows/DeriSock_Publish.yml
+++ b/.github/workflows/DeriSock_Publish.yml
@@ -33,4 +33,4 @@ jobs:
       run: dotnet pack --configuration Release
 
     - name: Publish nuget package
-      run: dotnet nuget push .\DeriSock\bin\Release\DeriSock.0.3.1.nupkg -k ${{secrets.NUGET_KEY}} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push .\DeriSock\bin\Release\DeriSock.0.3.2.nupkg -k ${{secrets.NUGET_KEY}} -s https://api.nuget.org/v3/index.json

--- a/DeriSock/DeriSock.csproj
+++ b/DeriSock/DeriSock.csproj
@@ -19,9 +19,9 @@
 
     <NeutralLanguage>en</NeutralLanguage>
 
-    <AssemblyVersion>0.3.1.0</AssemblyVersion>
-    <FileVersion>0.3.1.0</FileVersion>
-    <Version>0.3.1</Version>
+    <AssemblyVersion>0.3.2.0</AssemblyVersion>
+    <FileVersion>0.3.2.0</FileVersion>
+    <Version>0.3.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/DeriSock/DeribitV2Client.cs
+++ b/DeriSock/DeribitV2Client.cs
@@ -25,7 +25,7 @@ namespace DeriSock
     public event EventHandler<JsonRpcDisconnectEventArgs> Disconnected;
     private readonly IJsonRpcClient _client;
     private readonly SubscriptionManager _subscriptionManager;
-    protected readonly ILogger Logger = Log.Logger;
+    protected readonly ILogger Logger;
 
     public string AccessToken { get; private set; }
 
@@ -36,15 +36,17 @@ namespace DeriSock
     public string CloseStatusDescription => _client.CloseStatusDescription;
     public Exception Error => _client.Error;
 
-    public DeribitV2Client(DeribitEndpointType endpointType)
+    public DeribitV2Client(DeribitEndpointType endpointType, ILogger logger = null)
     {
+      Logger = logger ?? Log.Logger;
+
       switch (endpointType)
       {
         case DeribitEndpointType.Productive:
-          _client = JsonRpcClientFactory.Create(new Uri("wss://www.deribit.com/ws/api/v2"));
+          _client = JsonRpcClientFactory.Create(new Uri("wss://www.deribit.com/ws/api/v2"), Logger);
           break;
         case DeribitEndpointType.Testnet:
-          _client = JsonRpcClientFactory.Create(new Uri("wss://test.deribit.com/ws/api/v2"));
+          _client = JsonRpcClientFactory.Create(new Uri("wss://test.deribit.com/ws/api/v2"), Logger);
           break;
         default:
           throw new ArgumentOutOfRangeException(nameof(endpointType), endpointType, "Unsupported endpoint type");

--- a/DeriSock/JsonRpc/JsonRpcClient.cs
+++ b/DeriSock/JsonRpc/JsonRpcClient.cs
@@ -23,9 +23,10 @@
 
     protected IWebSocket Socket;
 
-    public JsonRpcClient(Uri serverUri)
+    public JsonRpcClient(Uri serverUri, ILogger logger)
     {
       ServerUri = serverUri;
+      Logger = logger;
       RequestMgr = new RequestManager(this);
     }
 

--- a/DeriSock/JsonRpc/JsonRpcClient.cs
+++ b/DeriSock/JsonRpc/JsonRpcClient.cs
@@ -15,7 +15,7 @@
 
   public class JsonRpcClient : IJsonRpcClient
   {
-    protected readonly ILogger Logger = Log.Logger;
+    protected readonly ILogger Logger;
     protected readonly RequestIdGenerator RequestIdGenerator = new RequestIdGenerator();
     protected readonly RequestManager RequestMgr;
     protected Thread ProcessReceiveThread;

--- a/DeriSock/JsonRpc/JsonRpcClientFactory.cs
+++ b/DeriSock/JsonRpc/JsonRpcClientFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace DeriSock.JsonRpc
 {
   using System;
+  using Serilog;
 
   public static class JsonRpcClientFactory
   {
@@ -11,9 +12,9 @@
       _factory = factory;
     }
 
-    public static IJsonRpcClient Create(Uri serverUri)
+    public static IJsonRpcClient Create(Uri serverUri, ILogger logger)
     {
-      return _factory != null ? _factory.Create(serverUri) : new JsonRpcClient(serverUri);
+      return _factory != null ? _factory.Create(serverUri) : new JsonRpcClient(serverUri, logger);
     }
   }
 }


### PR DESCRIPTION
DeribitV2Client will use the provided ILogger instance or Log.Looger
if null. This ILogger instance gets passed down to JsonRpcClient