### PR TITLE
fix!: some of the subscriptions didn't return an array

### DIFF
--- a/src/DeriSock.DevTools/ApiDoc/CodeGeneration/ApiInterfaceCodeGenerator.cs
+++ b/src/DeriSock.DevTools/ApiDoc/CodeGeneration/ApiInterfaceCodeGenerator.cs
@@ -5,6 +5,7 @@ namespace DeriSock.DevTools.ApiDoc.CodeGeneration;
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -182,7 +183,16 @@ internal class ApiInterfaceCodeGenerator : ApiDocCodeGenerator
 
       objMethod.Comments.Add(new CodeCommentStatement("<remarks>Don't forget to use this stream with <see cref=\"System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}\"/>.</remarks>", true));
 
-      objMethod.ReturnType = new CodeTypeReference(typeof(Task<>).Name, new CodeTypeReference(typeof(NotificationStream<>).Name, new CodeTypeReference(function.GetResponseTypeInfo()!.TypeName)));
+
+      var responseTypeInfo = function.GetResponseTypeInfo();
+      Debug.Assert(responseTypeInfo != null);
+
+      var notificationType = new CodeTypeReference(responseTypeInfo.TypeName);
+
+      if (responseTypeInfo.IsArray)
+        notificationType = new CodeTypeReference(responseTypeInfo.TypeName, 1);
+
+      objMethod.ReturnType = new CodeTypeReference(typeof(Task<>).Name, new CodeTypeReference(typeof(NotificationStream<>).Name, notificationType));
 
       var requestTypeInfo = function.GetRequestTypeInfo();
 

--- a/src/DeriSock.DevTools/ApiDoc/CodeGeneration/ApiInterfaceImplementationCodeGenerator.cs
+++ b/src/DeriSock.DevTools/ApiDoc/CodeGeneration/ApiInterfaceImplementationCodeGenerator.cs
@@ -5,6 +5,7 @@ namespace DeriSock.DevTools.ApiDoc.CodeGeneration;
 using System;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -248,10 +249,15 @@ internal class ApiInterfaceImplementationCodeGenerator : ApiDocCodeGenerator
       objMethod.Comments.Add(new CodeCommentStatement($"<inheritdoc cref=\"{interfaceName}.{objMethod.Name}\" />", true));
 
       // Defining return type
-      objMethod.ReturnType = new CodeTypeReference(typeof(Task<>).Name,
-                                                   new CodeTypeReference(
-                                                     typeof(NotificationStream<>).Name,
-                                                     new CodeTypeReference(function.GetResponseTypeInfo()!.TypeName)));
+      var responseTypeInfo = function.GetResponseTypeInfo();
+      Debug.Assert(responseTypeInfo != null);
+
+      var notificationType = new CodeTypeReference(responseTypeInfo.TypeName);
+
+      if (responseTypeInfo.IsArray)
+        notificationType = new CodeTypeReference(responseTypeInfo.TypeName, 1);
+
+      objMethod.ReturnType = new CodeTypeReference(typeof(Task<>).Name, new CodeTypeReference(typeof(NotificationStream<>).Name, notificationType));
 
       // Adding Parameters
       var requestTypeInfo = function.GetRequestTypeInfo();

--- a/src/DeriSock/Api/ISubscriptionsApi.g.cs
+++ b/src/DeriSock/Api/ISubscriptionsApi.g.cs
@@ -69,7 +69,7 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<DeribitPriceRankingEntry>> SubscribeDeribitPriceRanking(params DeribitPriceRankingChannel[] channels);
+    Task<NotificationStream<DeribitPriceRankingEntry[]>> SubscribeDeribitPriceRanking(params DeribitPriceRankingChannel[] channels);
     /// <summary>
     /// <para>This subscription provides basic statistics about Deribit Index</para>
     /// </summary>
@@ -113,7 +113,7 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<OptionMarkprice>> SubscribeMarkpriceOptions(params MarkpriceOptionsChannel[] channels);
+    Task<NotificationStream<OptionMarkprice[]>> SubscribeMarkpriceOptions(params MarkpriceOptionsChannel[] channels);
     /// <summary>
     /// <para>Provide current interest rate - but only for <b>perpetual</b> instruments. Other types won&apos;t generate any notification.</para>
     /// </summary>
@@ -169,7 +169,7 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<PublicTrade>> SubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels);
+    Task<NotificationStream<PublicTrade[]>> SubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels);
     /// <summary>
     /// <para>Get notifications about security events related to the account</para>
     /// </summary>
@@ -183,14 +183,14 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<UserChange>> SubscribeUserInstrumentChanges(params UserInstrumentChangesChannel[] channels);
+    Task<NotificationStream<UserChange[]>> SubscribeUserInstrumentChanges(params UserInstrumentChangesChannel[] channels);
     /// <summary>
     /// <para>Get notifications about changes in user&apos;s updates related to order, trades, etc. in instruments of a given kind and currency.</para>
     /// </summary>
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<UserChange>> SubscribeUserKindCurrencyChanges(params UserKindCurrencyChangesChannel[] channels);
+    Task<NotificationStream<UserChange[]>> SubscribeUserKindCurrencyChanges(params UserKindCurrencyChangesChannel[] channels);
     /// <summary>
     /// <para>Get notificiation when account is locked/unlocked</para>
     /// </summary>
@@ -218,7 +218,7 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<UserOrder>> SubscribeUserOrdersInstrumentChange(params UserOrdersInstrumentChangeChannel[] channels);
+    Task<NotificationStream<UserOrder[]>> SubscribeUserOrdersInstrumentChange(params UserOrdersInstrumentChangeChannel[] channels);
     /// <summary>
     /// <para>Get notifications about changes in user&apos;s orders in instruments of a given kind and currency.</para>
     /// </summary>
@@ -232,7 +232,7 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<UserOrder>> SubscribeUserOrdersKindCurrencyChange(params UserOrdersKindCurrencyChangeChannel[] channels);
+    Task<NotificationStream<UserOrder[]>> SubscribeUserOrdersKindCurrencyChange(params UserOrdersKindCurrencyChangeChannel[] channels);
     /// <summary>
     /// <para>Provides information about current user portfolio</para>
     /// </summary>
@@ -246,13 +246,13 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<UserTrade>> SubscribeUserTradesInstrumentChange(params UserTradesInstrumentChangeChannel[] channels);
+    Task<NotificationStream<UserTrade[]>> SubscribeUserTradesInstrumentChange(params UserTradesInstrumentChangeChannel[] channels);
     /// <summary>
     /// <para>Get notifications about user&apos;s trades in any instrument of a given kind and given currency.</para>
     /// </summary>
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-    Task<NotificationStream<UserTrade>> SubscribeUserTradesKindCurrencyChange(params UserTradesKindCurrencyChangeChannel[] channels);
+    Task<NotificationStream<UserTrade[]>> SubscribeUserTradesKindCurrencyChange(params UserTradesKindCurrencyChangeChannel[] channels);
   }
 }

--- a/src/DeriSock/Api/SubscriptionsApiImpl.g.cs
+++ b/src/DeriSock/Api/SubscriptionsApiImpl.g.cs
@@ -66,7 +66,7 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeDeribitPriceRanking" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<DeribitPriceRankingEntry>> ISubscriptionsApi.SubscribeDeribitPriceRanking(params DeribitPriceRankingChannel[] channels)
+      Task<NotificationStream<DeribitPriceRankingEntry[]>> ISubscriptionsApi.SubscribeDeribitPriceRanking(params DeribitPriceRankingChannel[] channels)
       {
         return _client.InternalSubscribeDeribitPriceRanking(channels);
       }
@@ -108,7 +108,7 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeMarkpriceOptions" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<OptionMarkprice>> ISubscriptionsApi.SubscribeMarkpriceOptions(params MarkpriceOptionsChannel[] channels)
+      Task<NotificationStream<OptionMarkprice[]>> ISubscriptionsApi.SubscribeMarkpriceOptions(params MarkpriceOptionsChannel[] channels)
       {
         return _client.InternalSubscribeMarkpriceOptions(channels);
       }
@@ -164,7 +164,7 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeKindCurrencyTrades" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<PublicTrade>> ISubscriptionsApi.SubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels)
+      Task<NotificationStream<PublicTrade[]>> ISubscriptionsApi.SubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels)
       {
         return _client.InternalSubscribeKindCurrencyTrades(channels);
       }
@@ -178,14 +178,14 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeUserInstrumentChanges" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<UserChange>> ISubscriptionsApi.SubscribeUserInstrumentChanges(params UserInstrumentChangesChannel[] channels)
+      Task<NotificationStream<UserChange[]>> ISubscriptionsApi.SubscribeUserInstrumentChanges(params UserInstrumentChangesChannel[] channels)
       {
         return _client.InternalSubscribeUserInstrumentChanges(channels);
       }
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeUserKindCurrencyChanges" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<UserChange>> ISubscriptionsApi.SubscribeUserKindCurrencyChanges(params UserKindCurrencyChangesChannel[] channels)
+      Task<NotificationStream<UserChange[]>> ISubscriptionsApi.SubscribeUserKindCurrencyChanges(params UserKindCurrencyChangesChannel[] channels)
       {
         return _client.InternalSubscribeUserKindCurrencyChanges(channels);
       }
@@ -213,7 +213,7 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeUserOrdersInstrumentChange" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<UserOrder>> ISubscriptionsApi.SubscribeUserOrdersInstrumentChange(params UserOrdersInstrumentChangeChannel[] channels)
+      Task<NotificationStream<UserOrder[]>> ISubscriptionsApi.SubscribeUserOrdersInstrumentChange(params UserOrdersInstrumentChangeChannel[] channels)
       {
         return _client.InternalSubscribeUserOrdersInstrumentChange(channels);
       }
@@ -227,7 +227,7 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeUserOrdersKindCurrencyChange" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<UserOrder>> ISubscriptionsApi.SubscribeUserOrdersKindCurrencyChange(params UserOrdersKindCurrencyChangeChannel[] channels)
+      Task<NotificationStream<UserOrder[]>> ISubscriptionsApi.SubscribeUserOrdersKindCurrencyChange(params UserOrdersKindCurrencyChangeChannel[] channels)
       {
         return _client.InternalSubscribeUserOrdersKindCurrencyChange(channels);
       }
@@ -241,14 +241,14 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeUserTradesInstrumentChange" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<UserTrade>> ISubscriptionsApi.SubscribeUserTradesInstrumentChange(params UserTradesInstrumentChangeChannel[] channels)
+      Task<NotificationStream<UserTrade[]>> ISubscriptionsApi.SubscribeUserTradesInstrumentChange(params UserTradesInstrumentChangeChannel[] channels)
       {
         return _client.InternalSubscribeUserTradesInstrumentChange(channels);
       }
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeUserTradesKindCurrencyChange" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "0.3.5")]
-      Task<NotificationStream<UserTrade>> ISubscriptionsApi.SubscribeUserTradesKindCurrencyChange(params UserTradesKindCurrencyChangeChannel[] channels)
+      Task<NotificationStream<UserTrade[]>> ISubscriptionsApi.SubscribeUserTradesKindCurrencyChange(params UserTradesKindCurrencyChangeChannel[] channels)
       {
         return _client.InternalSubscribeUserTradesKindCurrencyChange(channels);
       }

--- a/src/DeriSock/DeribitClient_Subscriptions.cs
+++ b/src/DeriSock/DeribitClient_Subscriptions.cs
@@ -21,8 +21,8 @@ public partial class DeribitClient
   private async Task<NotificationStream<DeribitPriceIndex>> InternalSubscribeDeribitPriceIndex(params DeribitPriceIndexChannel[] channels)
     => await _subscriptionManager.Subscribe<DeribitPriceIndex, DeribitPriceIndexChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<DeribitPriceRankingEntry>> InternalSubscribeDeribitPriceRanking(params DeribitPriceRankingChannel[] channels)
-    => await _subscriptionManager.Subscribe<DeribitPriceRankingEntry, DeribitPriceRankingChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<DeribitPriceRankingEntry[]>> InternalSubscribeDeribitPriceRanking(params DeribitPriceRankingChannel[] channels)
+    => await _subscriptionManager.Subscribe<DeribitPriceRankingEntry[], DeribitPriceRankingChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<DeribitPriceStatistics>> InternalSubscribeDeribitPriceStatistics(params DeribitPriceStatisticsChannel[] channels)
     => await _subscriptionManager.Subscribe<DeribitPriceStatistics, DeribitPriceStatisticsChannel>(channels).ConfigureAwait(false);
@@ -39,8 +39,8 @@ public partial class DeribitClient
   private async Task<NotificationStream<InstrumentState>> InternalSubscribeInstrumentState(params InstrumentStateChannel[] channels)
     => await _subscriptionManager.Subscribe<InstrumentState, InstrumentStateChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<OptionMarkprice>> InternalSubscribeMarkpriceOptions(params MarkpriceOptionsChannel[] channels)
-    => await _subscriptionManager.Subscribe<OptionMarkprice, MarkpriceOptionsChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<OptionMarkprice[]>> InternalSubscribeMarkpriceOptions(params MarkpriceOptionsChannel[] channels)
+    => await _subscriptionManager.Subscribe<OptionMarkprice[], MarkpriceOptionsChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<PerpetualInterestRate>> InternalSubscribePerpetual(params PerpetualChannel[] channels)
     => await _subscriptionManager.Subscribe<PerpetualInterestRate, PerpetualChannel>(channels).ConfigureAwait(false);
@@ -63,17 +63,17 @@ public partial class DeribitClient
   private async Task<NotificationStream<PublicTrade>> InternalSubscribeInstrumentTrades(params InstrumentTradesChannel[] channels)
     => await _subscriptionManager.Subscribe<PublicTrade, InstrumentTradesChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<PublicTrade>> InternalSubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels)
-    => await _subscriptionManager.Subscribe<PublicTrade, KindCurrencyTradesChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<PublicTrade[]>> InternalSubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels)
+    => await _subscriptionManager.Subscribe<PublicTrade[], KindCurrencyTradesChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<AccessLogEntry>> InternalSubscribeUserAccessLog(params UserAccessLogChannel[] channels)
     => await _subscriptionManager.Subscribe<AccessLogEntry, UserAccessLogChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<UserChange>> InternalSubscribeUserInstrumentChanges(params UserInstrumentChangesChannel[] channels)
-    => await _subscriptionManager.Subscribe<UserChange, UserInstrumentChangesChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<UserChange[]>> InternalSubscribeUserInstrumentChanges(params UserInstrumentChangesChannel[] channels)
+    => await _subscriptionManager.Subscribe<UserChange[], UserInstrumentChangesChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<UserChange>> InternalSubscribeUserKindCurrencyChanges(params UserKindCurrencyChangesChannel[] channels)
-    => await _subscriptionManager.Subscribe<UserChange, UserKindCurrencyChangesChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<UserChange[]>> InternalSubscribeUserKindCurrencyChanges(params UserKindCurrencyChangesChannel[] channels)
+    => await _subscriptionManager.Subscribe<UserChange[], UserKindCurrencyChangesChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<UserLockNotification>> InternalSubscribeUserLock(params UserLockChannel[] channels)
     => await _subscriptionManager.Subscribe<UserLockNotification, UserLockChannel>(channels).ConfigureAwait(false);
@@ -84,21 +84,21 @@ public partial class DeribitClient
   private async Task<NotificationStream<UserOrder>> InternalSubscribeUserOrdersInstrumentChangeRaw(params UserOrdersInstrumentChangeRawChannel[] channels)
     => await _subscriptionManager.Subscribe<UserOrder, UserOrdersInstrumentChangeRawChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<UserOrder>> InternalSubscribeUserOrdersInstrumentChange(params UserOrdersInstrumentChangeChannel[] channels)
-    => await _subscriptionManager.Subscribe<UserOrder, UserOrdersInstrumentChangeChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<UserOrder[]>> InternalSubscribeUserOrdersInstrumentChange(params UserOrdersInstrumentChangeChannel[] channels)
+    => await _subscriptionManager.Subscribe<UserOrder[], UserOrdersInstrumentChangeChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<UserOrder>> InternalSubscribeUserOrdersKindCurrencyChangeRaw(params UserOrdersKindCurrencyChangeRawChannel[] channels)
     => await _subscriptionManager.Subscribe<UserOrder, UserOrdersKindCurrencyChangeRawChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<UserOrder>> InternalSubscribeUserOrdersKindCurrencyChange(params UserOrdersKindCurrencyChangeChannel[] channels)
-    => await _subscriptionManager.Subscribe<UserOrder, UserOrdersKindCurrencyChangeChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<UserOrder[]>> InternalSubscribeUserOrdersKindCurrencyChange(params UserOrdersKindCurrencyChangeChannel[] channels)
+    => await _subscriptionManager.Subscribe<UserOrder[], UserOrdersKindCurrencyChangeChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<UserPortfolioNotification>> InternalSubscribeUserPortfolio(params UserPortfolioChannel[] channels)
     => await _subscriptionManager.Subscribe<UserPortfolioNotification, UserPortfolioChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<UserTrade>> InternalSubscribeUserTradesInstrumentChange(params UserTradesInstrumentChangeChannel[] channels)
-    => await _subscriptionManager.Subscribe<UserTrade, UserTradesInstrumentChangeChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<UserTrade[]>> InternalSubscribeUserTradesInstrumentChange(params UserTradesInstrumentChangeChannel[] channels)
+    => await _subscriptionManager.Subscribe<UserTrade[], UserTradesInstrumentChangeChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<UserTrade>> InternalSubscribeUserTradesKindCurrencyChange(params UserTradesKindCurrencyChangeChannel[] channels)
-    => await _subscriptionManager.Subscribe<UserTrade, UserTradesKindCurrencyChangeChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<UserTrade[]>> InternalSubscribeUserTradesKindCurrencyChange(params UserTradesKindCurrencyChangeChannel[] channels)
+    => await _subscriptionManager.Subscribe<UserTrade[], UserTradesKindCurrencyChangeChannel>(channels).ConfigureAwait(false);
 }

--- a/test/DeriSock.Tests.Integration/Notifications.cs
+++ b/test/DeriSock.Tests.Integration/Notifications.cs
@@ -35,7 +35,7 @@ public class Notifications : IAsyncLifetime
     // Assert
     receivedNotifications.Should().NotBeEmpty("there has to be at least one notification received");
   }
-
+  
   /// <inheritdoc />
   public async Task InitializeAsync()
   {


### PR DESCRIPTION
The following subscriptions did not return an array:
- SubscribeDeribitPriceRanking
- SubscribeMarkpriceOptions
- SubscribeKindCurrencyTrades
- SubscribeUserInstrumentChanges
- SubscribeUserKindCurrencyChanges
- SubscribeUserOrdersInstrumentChange
- SubscribeUserOrdersKindCurrencyChange
- SubscribeUserTradesInstrumentChange
- SubscribeUserTradesKindCurrencyChange

Refs: #46