### PR TITLE
fix!: corrected notification data type in subscription to channel trades.{instrument_name}.{interval}

### DIFF
--- a/src/DeriSock.DevTools/Data/deribit.api.v211.00.fixes.overrides.json
+++ b/src/DeriSock.DevTools/Data/deribit.api.v211.00.fixes.overrides.json
@@ -52,7 +52,7 @@
         "properties": {
           "underlying_index": {
             "apiDataType": "string",
-            "dataType": "string" 
+            "dataType": "string"
           }
         }
       }
@@ -65,6 +65,13 @@
             "dataType": "string"
           }
         }
+      }
+    },
+    "trades.{instrument_name}.{interval}": {
+      "response": {
+        "apiDataType": "array of objects",
+        "dataType": "array",
+        "arrayDataType": "PublicTrade"
       }
     }
   }

--- a/src/DeriSock.DevTools/Data/deribit.api.v211.31.object-types.overrides.json
+++ b/src/DeriSock.DevTools/Data/deribit.api.v211.31.object-types.overrides.json
@@ -843,7 +843,7 @@
   "subscriptions": {
     "trades.{instrument_name}.{interval}": {
       "response": {
-        "dataType": "PublicTrade"
+        "arrayDataType": "PublicTrade"
       }
     },
     "trades.{kind}.{currency}.{interval}": {

--- a/src/DeriSock.DevTools/Data/deribit.api.v211.json
+++ b/src/DeriSock.DevTools/Data/deribit.api.v211.json
@@ -16787,8 +16787,9 @@
       },
       "response": {
         "required": true,
-        "apiDataType": "object",
-        "dataType": "PublicTrade",
+        "apiDataType": "array of objects",
+        "dataType": "array",
+        "arrayDataType": "PublicTrade",
         "properties": {
           "amount": {
             "description": "Trade amount. For perpetual and futures - in USD units, for options it is amount of corresponding cryptocurrency contracts, e.g., BTC or ETH.",

--- a/src/DeriSock.DevTools/Properties/launchSettings.json
+++ b/src/DeriSock.DevTools/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "DeriSock.DevTools": {
       "commandName": "Project",
-      "commandLineArgs": "--create-base --create-object-map --create-object-overrides --create-enum-map --create-enum-overrides --create-request-map --create-request-overrides --generate-code"
+      "commandLineArgs": "--create-base --create-object-map --create-object-overrides --create-enum-map --create-enum-overrides --create-request-map --create-request-overrides --create-final --generate-code"
     }
   }
 }

--- a/src/DeriSock/Api/ISubscriptionsApi.g.cs
+++ b/src/DeriSock/Api/ISubscriptionsApi.g.cs
@@ -162,7 +162,7 @@ namespace DeriSock.Api
     /// <remarks>Don't forget to use this stream with <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation{T}"/>.</remarks>
     /// <param name="channels"></param>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "2.0.0")]
-    Task<NotificationStream<PublicTrade>> SubscribeInstrumentTrades(params InstrumentTradesChannel[] channels);
+    Task<NotificationStream<PublicTrade[]>> SubscribeInstrumentTrades(params InstrumentTradesChannel[] channels);
     /// <summary>
     /// <para>Get notifications about trades in any instrument of a given kind and given currency.</para>
     /// </summary>

--- a/src/DeriSock/Api/SubscriptionsApiImpl.g.cs
+++ b/src/DeriSock/Api/SubscriptionsApiImpl.g.cs
@@ -157,7 +157,7 @@ namespace DeriSock
       /// <inheritdoc cref="ISubscriptionsApi.SubscribeInstrumentTrades" />
       /// <param name="channels"></param>
       [System.CodeDom.Compiler.GeneratedCodeAttribute("DeriSock.DevTools", "2.0.0")]
-      Task<NotificationStream<PublicTrade>> ISubscriptionsApi.SubscribeInstrumentTrades(params InstrumentTradesChannel[] channels)
+      Task<NotificationStream<PublicTrade[]>> ISubscriptionsApi.SubscribeInstrumentTrades(params InstrumentTradesChannel[] channels)
       {
         return _client.InternalSubscribeInstrumentTrades(channels);
       }

--- a/src/DeriSock/DeriSock.csproj
+++ b/src/DeriSock/DeriSock.csproj
@@ -36,7 +36,6 @@
 
   <ItemGroup>
     <None Remove="DeriSock.csproj.DotSettings" />
-    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DeriSock/DeribitClient_Subscriptions.cs
+++ b/src/DeriSock/DeribitClient_Subscriptions.cs
@@ -60,8 +60,8 @@ public partial class DeribitClient
   private async Task<NotificationStream<TickerData>> InternalSubscribeTicker(params TickerChannel[] channels)
     => await _subscriptionManager.Subscribe<TickerData, TickerChannel>(channels).ConfigureAwait(false);
 
-  private async Task<NotificationStream<PublicTrade>> InternalSubscribeInstrumentTrades(params InstrumentTradesChannel[] channels)
-    => await _subscriptionManager.Subscribe<PublicTrade, InstrumentTradesChannel>(channels).ConfigureAwait(false);
+  private async Task<NotificationStream<PublicTrade[]>> InternalSubscribeInstrumentTrades(params InstrumentTradesChannel[] channels)
+    => await _subscriptionManager.Subscribe<PublicTrade[], InstrumentTradesChannel>(channels).ConfigureAwait(false);
 
   private async Task<NotificationStream<PublicTrade[]>> InternalSubscribeKindCurrencyTrades(params KindCurrencyTradesChannel[] channels)
     => await _subscriptionManager.Subscribe<PublicTrade[], KindCurrencyTradesChannel>(channels).ConfigureAwait(false);


### PR DESCRIPTION
Official documentation states that this notification holds an object as data, but it is an array of objects.