### PR TITLE
Add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,29 @@ await client.Connect();
 
 await client.Disconnect();
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L12-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-connect-disconnect' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L14-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-connect-disconnect' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+To use a proxy, you can assign an `IWebProxy` instance to the default `ITextMessageClient` implementation (`TextMessageMessageWebSocketClient`) and pass it to the `DeribitClient` constructor.
+
+<!-- snippet: readme-webproxy -->
+<a id='snippet-readme-webproxy'></a>
+```cs
+// Use a web proxy to connect to the API
+
+var messageSource = new TextMessageWebSocketClient(null);
+messageSource.Proxy = new WebProxy("socks5://socks5.example.com:1080")
+{
+  Credentials = new NetworkCredential
+  {
+    UserName = "username",
+    Password = "password"
+  }
+};
+
+var clientWithProxy = new DeribitClient(EndpointType.Testnet, messageSource);
+```
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L25-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-webproxy' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The various methods are organized in categories (Authentication, Supporting, Market Data, ...) and scopes (Private, Public).
@@ -52,7 +74,7 @@ if (response.Data is null) {
 
 var bestBidPrice = response.Data.BestBidPrice;
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L23-L42' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-req-bbp-1' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L44-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-req-bbp-1' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Example:** Calling `GetOrderBook` from the `MarketData` category.
@@ -78,7 +100,7 @@ if (response.Data is null) {
 
 var bestBidPrice = response.Data.BestBidPrice;
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L46-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-req-bbp-2' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L67-L86' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-req-bbp-2' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Authentication
@@ -97,7 +119,7 @@ await client.Authentication.PublicLogin()
     "<optional state>",
     "<optional scope>");
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L69-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-auth-credentials' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L90-L98' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-auth-credentials' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Authentication using Signature
@@ -112,7 +134,7 @@ await client.Authentication.PublicLogin()
     "<optional state>",
     "<optional scope>");
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L81-L89' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-auth-signature' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L102-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-auth-signature' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ### Logout
@@ -124,7 +146,7 @@ When authenticated, you can logout like this (this is the only synchroneous meth
 ```cs
 client.Authentication.PrivateLogout();
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L93-L96' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-auth-logout' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L114-L117' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-auth-logout' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Note:** The server will automatically close the connection when you logout
@@ -138,7 +160,7 @@ This is also the reason why the subscription methods are not present in the `Pub
 <!-- snippet: readme-subscribtion-usage -->
 <a id='snippet-readme-subscribtion-usage'></a>
 ```cs
-// Subscribe to one or more channels. 
+// Subscribe to one or more channels.
 var subscriptionStream = await client.Subscriptions.SubscribeBookChanges(
                            new BookChangesChannel
                            {
@@ -162,5 +184,5 @@ await foreach (var notification in subscriptionStream.WithCancellation(cts.Token
   var bookChangeId = notification.Data.ChangeId;
 }
 ```
-<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L100-L125' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-subscribtion-usage' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DeriSock.DevTools/Snippets.cs#L121-L146' title='Snippet source file'>snippet source</a> | <a href='#snippet-readme-subscribtion-usage' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/README.source.md
+++ b/README.source.md
@@ -9,6 +9,10 @@ To connect to the Deribit Network just instantiate a new instance of the `Deribi
 
 snippet: readme-connect-disconnect
 
+To use a proxy, you can assign an `IWebProxy` instance to the default `ITextMessageClient` implementation (`TextMessageMessageWebSocketClient`) and pass it to the `DeribitClient` constructor.
+
+snippet: readme-webproxy
+
 The various methods are organized in categories (Authentication, Supporting, Market Data, ...) and scopes (Private, Public).
 
 **Example:** Calling `GetOrderBook` from the `Public` scope.

--- a/src/DeriSock.DevTools/Snippets.cs
+++ b/src/DeriSock.DevTools/Snippets.cs
@@ -1,9 +1,11 @@
 namespace DeriSock.DevTools;
 
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
 using DeriSock.Model;
+using DeriSock.Net;
 
 public class Snippets
 {
@@ -18,6 +20,25 @@ public class Snippets
     await client.Disconnect();
 
     // end-snippet
+
+    {
+      // begin-snippet: readme-webproxy
+      // Use a web proxy to connect to the API
+
+      var messageSource = new TextMessageWebSocketClient(null);
+      messageSource.Proxy = new WebProxy("socks5://socks5.example.com:1080")
+      {
+        Credentials = new NetworkCredential
+        {
+          UserName = "username",
+          Password = "password"
+        }
+      };
+
+      var clientWithProxy = new DeribitClient(EndpointType.Testnet, messageSource);
+
+      // end-snippet
+    }
 
     {
       // begin-snippet: readme-req-bbp-1
@@ -98,7 +119,7 @@ public class Snippets
 
     {
       // begin-snippet: readme-subscribtion-usage
-      // Subscribe to one or more channels. 
+      // Subscribe to one or more channels.
       var subscriptionStream = await client.Subscriptions.SubscribeBookChanges(
                                  new BookChangesChannel
                                  {

--- a/src/DeriSock/Net/ITextMessageClient.cs
+++ b/src/DeriSock/Net/ITextMessageClient.cs
@@ -2,6 +2,7 @@ namespace DeriSock.Net;
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,6 +16,11 @@ public interface ITextMessageClient : IAsyncDisposable
   ///   Gets, if the <see cref="ITextMessageClient" /> is connected with the endpoint and ready to operate.
   /// </summary>
   public bool IsConnected { get; }
+
+  /// <summary>
+  ///   Gets or sets the proxy to use when connecting to the endpoint.
+  /// </summary>
+  public IWebProxy? Proxy { get; set; }
 
   /// <summary>
   ///   Connects to the endpoint.

--- a/src/DeriSock/Net/TextMessageWebSocketClient.cs
+++ b/src/DeriSock/Net/TextMessageWebSocketClient.cs
@@ -3,6 +3,7 @@ namespace DeriSock.Net;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
@@ -28,6 +29,9 @@ public sealed class TextMessageWebSocketClient : ITextMessageClient
   /// <inheritdoc />
   public bool IsConnected { get; private set; }
 
+  /// <inheritdoc />
+  public IWebProxy? Proxy { get; set; }
+
   /// <summary>
   ///   Creates an instance of the <see cref="TextMessageWebSocketClient" /> class.
   /// </summary>
@@ -46,6 +50,9 @@ public sealed class TextMessageWebSocketClient : ITextMessageClient
     _webSocketEndpoint = endpoint;
 
     _webSocket = new ClientWebSocket();
+
+    if (Proxy is not null)
+      _webSocket.Options.Proxy = Proxy;
 
     _logger?.Information("Connecting to {Endpoint}", _webSocketEndpoint);
 


### PR DESCRIPTION
Adding support to use a proxy in the default `ITextMessageClient` implementation.